### PR TITLE
test: fix demo URL

### DIFF
--- a/src/test/java/com/flowingcode/vaadin/addons/regex/RegularExpressionFieldDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/regex/RegularExpressionFieldDemo.java
@@ -29,7 +29,7 @@ import java.util.regex.Pattern;
 @DemoSource
 @PageTitle("Regular Expression Field Add-on Demo")
 @SuppressWarnings("serial")
-@Route(value = "demo", layout = RegularExpressionFieldView.class)
+@Route(value = "regular-expression-field/demo", layout = RegularExpressionFieldView.class)
 public class RegularExpressionFieldDemo extends Div {
 
   public RegularExpressionFieldDemo() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the demo route path from “/demo” to “/regular-expression-field/demo” for clearer navigation.
  * No functional or public API changes.
  * Users accessing the demo should update bookmarks or links to the new path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->